### PR TITLE
fix(sec): upgrade com.h2database:h2 to 2.1.210

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -190,7 +190,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.191</version>
+            <version>2.1.210</version>
             <scope>test</scope>
         </dependency>
 
@@ -210,7 +210,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.197</version>
+            <version>2.1.210</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
### What happened？
There are 3 security vulnerabilities found in com.h2database:h2 1.4.197
- [CVE-2018-14335](https://www.oscs1024.com/hd/CVE-2018-14335)
- [CVE-2021-42392](https://www.oscs1024.com/hd/CVE-2021-42392)
- [CVE-2022-23221](https://www.oscs1024.com/hd/CVE-2022-23221)


### What did I do？
Upgrade com.h2database:h2 from 1.4.197 to 2.1.210 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS