### PR TITLE
fix(sec): upgrade io.netty:netty-handler to 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netty.version>4.1.68.Final</netty.version>
+        <netty.version>4.1.94.final</netty.version>
         <source.version>1.8</source.version>
         <target.version>1.8</target.version>
     </properties>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-handler 4.1.68.Final
- [MPS-2022-12067](https://www.oscs1024.com/hd/MPS-2022-12067)


### What did I do？
Upgrade io.netty:netty-handler from 4.1.68.Final to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS